### PR TITLE
Allow exe.config to be refreshed without restarting the application

### DIFF
--- a/QuickOpener/MainForm.cs
+++ b/QuickOpener/MainForm.cs
@@ -50,10 +50,9 @@ namespace QuickOpener
             string atomName = Guid.NewGuid().ToString();
             _hotKeyId = GlobalAddAtom(atomName);
 
-            // Register CTRL+ALT+Up
+            // Register CTRL+ALT+SPACE
             RegisterHotKey(Handle, _hotKeyId, MOD_CONTROL | MOD_ALT, (int)Keys.Space);
         }
-
 
         private void MainForm_FormClosed(object sender, FormClosedEventArgs e)
         {

--- a/QuickOpener/MainForm.cs
+++ b/QuickOpener/MainForm.cs
@@ -94,6 +94,19 @@ namespace QuickOpener
 
                     txtCommand.Text = "";
                 }
+                else if (string.Compare("refresh", txtCommand.Text.Trim(), true) == 0)
+                {
+                    // trigger the application to re-read the config file
+                    ConfigurationManager.RefreshSection("appSettings");
+
+                    LogToScreen("config refreshed");
+
+                    // Add the command to the history
+                    _history.Add(txtCommand.Text);
+                    _historyPointer = _history.Count;
+
+                    txtCommand.Text = "";
+                }
                 else
                 {
                     string path = "";


### PR DESCRIPTION
Added a new section to KeyDown to look for a keyword of refresh in order to force the application to refresh its configuration while running. This prevents the need to restart the application in order to see config changes.